### PR TITLE
added support for optional running of one ets table per module.

### DIFF
--- a/lib/memoize/application.ex
+++ b/lib/memoize/application.ex
@@ -7,15 +7,16 @@ defmodule Memoize.Application do
   @cache_strategy Application.get_env(:memoize, :cache_strategy, Memoize.CacheStrategy.Default)
 
   def start(_type, _args) do
-    Supervisor.start_link(__MODULE__, [], strategy: :one_for_one)
+    Supervisor.start_link(__MODULE__, [], strategy: :one_for_one, name: __MODULE__)
   end
 
   def stop(_state) do
     :ok
   end
 
-  def init(_) do
-    @cache_strategy.init()
+  def init(_opts) do
+    caches = Application.get_env(:memoize, :caches)
+    @cache_strategy.init(caches: caches)
     Supervisor.Spec.supervise([], strategy: :one_for_one)
   end
 

--- a/lib/memoize/cache_strategy.ex
+++ b/lib/memoize/cache_strategy.ex
@@ -1,11 +1,14 @@
 defmodule Memoize.CacheStrategy do
-  @callback init() :: any
-  @callback tab(any) :: atom
-  @callback cache(any, any, Keyword.t()) :: any
-  @callback read(any, any, any) :: :ok | :retry
+  @callback init(Keyword.t()) :: any
+  @callback tab(atom, any) :: atom
+  @callback cache(atom, any, any, Keyword.t()) :: any
+  @callback read(atom, any, any, any) :: :ok | :retry
   @callback invalidate() :: integer
-  @callback invalidate(any) :: integer
+  @callback invalidate(atom) :: integer
+  @callback invalidate(atom, atom) :: integer
+  @callback invalidate(atom, atom, any) :: integer
   @callback garbage_collect() :: integer
+  @callback garbage_collect(atom) :: integer
 
   def configured?(mod) do
     Application.get_env(:memoize, :cache_strategy, Memoize.CacheStrategy.Default) == mod

--- a/lib/memoize/cache_strategy/default.ex
+++ b/lib/memoize/cache_strategy/default.ex
@@ -4,18 +4,35 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Default) do
 
     @behaviour Memoize.CacheStrategy
 
-    @ets_tab __MODULE__
+    @default_expires_in Application.get_env(:memoize, :expires_in, :infinity)
 
-    def init() do
-      :ets.new(@ets_tab, [:public, :set, :named_table, {:read_concurrency, true}])
+    @ets_tab __MODULE__
+    alias Memoize.Cache
+
+    def init(opts) do
+      case Keyword.get(opts, :caches) do
+        nil ->
+          :ets.new(tab(nil), [:public, :set, :named_table, {:read_concurrency, true}])
+
+        caches ->
+          Enum.each(caches, fn cache ->
+            :ets.new(tab(cache), [:public, :set, :named_table, {:read_concurrency, true}])
+          end)
+      end
     end
 
-    def tab(_key) do
+    def tab(_module, _key \\ nil)
+
+    def tab(nil, _key) do
       @ets_tab
     end
 
-    def cache(_key, _value, opts) do
-      expires_in = Keyword.get(opts, :expires_in, :infinity)
+    def tab(module, _key) do
+      Module.concat(@ets_tab, module)
+    end
+
+    def cache(_module, _key, _value, opts) do
+      expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
 
       expired_at =
         case expires_in do
@@ -26,30 +43,118 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Default) do
       expired_at
     end
 
-    def read(key, _value, expired_at) do
+    def read(cache_name, key, _value, expired_at) do
       if expired_at != :infinity && System.monotonic_time(:millisecond) > expired_at do
-        invalidate(key)
+        local_invalidate(cache_name, key)
         :retry
       else
         :ok
       end
     end
 
-    def invalidate() do
-      :ets.select_delete(@ets_tab, [{{:_, {:completed, :_, :_}}, [], [true]}])
+    defp local_invalidate(cache_name, key) do
+      :ets.select_delete(tab(cache_name), [{{key, {:completed, :_, :_}}, [], [true]}])
     end
 
-    def invalidate(key) do
-      :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
+    def invalidate() do
+      # this is only place we have to run get_env, but given we are deleting everything its fine.
+      case Application.get_env(:memoize, :caches) do
+        nil ->
+          :ets.select_delete(tab(nil), [{{:_, {:completed, :_, :_}}, [], [true]}])
+
+        modules ->
+          Enum.reduce(modules, 0, fn module, acc ->
+            :ets.select_delete(tab(module), [{{:_, {:completed, :_, :_}}, [], [true]}]) + acc
+          end)
+      end
+    end
+
+    def invalidate(module) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([{{key(cache_name, module), {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module, function), {:completed, :_, :_}}, [], [true]}
+      ])
+    end
+
+    def invalidate(module, function, args) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module, function, args), {:completed, :_, :_}}, [], [true]}
+      ])
     end
 
     def garbage_collect() do
       expired_at = System.monotonic_time(:millisecond)
+      # this is only place we have to run get_env, but given we are deleting everything its fine.
+      case Application.get_env(:memoize, :caches) do
+        nil ->
+          :ets.select_delete(tab(nil), [
+            {{:_, {:completed, :_, :"$1"}},
+             [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+          ])
 
-      :ets.select_delete(@ets_tab, [
-        {{:_, {:completed, :_, :"$1"}},
+        modules ->
+          Enum.reduce(modules, 0, fn module, acc ->
+            :ets.select_delete(tab(module), [
+              {{:_, {:completed, :_, :"$1"}},
+               [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+            ]) + acc
+          end)
+      end
+    end
+
+    def garbage_collect(module) do
+      expired_at = System.monotonic_time(:millisecond)
+
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module), {:completed, :_, :"$1"}},
          [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
       ])
+    end
+
+    # ets per module
+    defp key(module_name, module_name) do
+      {:_, :_}
+    end
+
+    defp key(_cache_name, module_name) do
+      {module_name, :_, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name) do
+      {function_name, :_}
+    end
+
+    defp key(_cache_name, module_name, function_name) do
+      {module_name, function_name, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name, args) do
+      {function_name, args}
+    end
+
+    defp key(_cache_name, module_name, function_name, args) do
+      {module_name, function_name, args}
     end
   end
 end

--- a/lib/memoize/cache_strategy/simple.ex
+++ b/lib/memoize/cache_strategy/simple.ex
@@ -1,0 +1,78 @@
+if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Simple) do
+  defmodule Memoize.CacheStrategy.Simple do
+    @moduledoc false
+
+    @behaviour Memoize.CacheStrategy
+
+    @ets_tab __MODULE__
+
+    def init(_) do
+      :ets.new(@ets_tab, [:public, :set, :named_table, {:read_concurrency, true}])
+    end
+
+    def tab(_module, _key \\ nil) do
+      @ets_tab
+    end
+
+    def cache(_module, _key, _value, opts) do
+      expires_in = Keyword.get(opts, :expires_in, :infinity)
+
+      expired_at =
+        case expires_in do
+          :infinity -> :infinity
+          value -> System.monotonic_time(:millisecond) + value
+        end
+
+      expired_at
+    end
+
+    def read(_module, key, _value, expired_at) do
+      if expired_at != :infinity && System.monotonic_time(:millisecond) > expired_at do
+        local_invalidate(key)
+        :retry
+      else
+        :ok
+      end
+    end
+
+    defp local_invalidate(key) do
+      :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate() do
+      :ets.select_delete(@ets_tab, [{{:_, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module) do
+      :ets.select_delete(@ets_tab, [{{{module, :_, :_}, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function) do
+      :ets.select_delete(@ets_tab, [{{{module, function, :_}, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function, args) do
+      :ets.select_delete(@ets_tab, [
+        {{{module, function, args}, {:completed, :_, :_}}, [], [true]}
+      ])
+    end
+
+    def garbage_collect() do
+      expired_at = System.monotonic_time(:millisecond)
+
+      :ets.select_delete(@ets_tab, [
+        {{:_, {:completed, :_, :"$1"}},
+         [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+      ])
+    end
+
+    def garbage_collect(module) do
+      expired_at = System.monotonic_time(:millisecond)
+
+      :ets.select_delete(@ets_tab, [
+        {{{module, :_, :_}, {:completed, :_, :"$1"}},
+         [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+      ])
+    end
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm", "b42a23e9bd92d65d16db2f75553982e58519054095356a418bb8320bbacb58b1"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "dc87f778d8260da0189a622f62790f6202af72f2f3dee6e78d91a18dd2fcd137"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "d7152ff93f2eac07905f510dfa03397134345ba4673a00fbf7119bab98632940"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "4a36dd2d0d5c5f98d95b3f410d7071cd661d5af310472229dd0e92161f168a44"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm", "ebb595e19456a72786db6dcd370d320350cb624f0b6203fcc7e23161d49b0ffb"},
 }

--- a/test/memoize_test.exs
+++ b/test/memoize_test.exs
@@ -3,6 +3,8 @@ defmodule MemoizeTest do
 
   use Memoize
 
+  alias Memoize.Cache
+
   defmemo foo(x, y) when x == 0 do
     y
   end
@@ -46,16 +48,16 @@ defmodule MemoizeTest do
   test "invalidates cached values when call invalidate/{0-3}" do
     f = fn -> 10 end
 
-    Memoize.Cache.invalidate()
-    Memoize.Cache.get_or_run({:mod1, :fun1, [1]}, f)
-    Memoize.Cache.get_or_run({:mod1, :fun1, [2]}, f)
-    Memoize.Cache.get_or_run({:mod1, :fun2, [1]}, f)
-    Memoize.Cache.get_or_run({:mod2, :fun1, [1]}, f)
+    Cache.invalidate()
+    Cache.get_or_run(:mod1, :fun1, [1], f)
+    Cache.get_or_run(:mod1, :fun1, [2], f)
+    Cache.get_or_run(:mod1, :fun2, [1], f)
+    Cache.get_or_run(:mod2, :fun1, [1], f)
 
-    assert 1 == Memoize.invalidate(:mod1, :fun1, [1])
-    assert 1 == Memoize.invalidate(:mod1, :fun1)
-    assert 1 == Memoize.invalidate(:mod1)
-    assert 1 == Memoize.invalidate()
+    assert 1 == Cache.invalidate(:mod1, :fun1, [1])
+    assert 1 == Cache.invalidate(:mod1, :fun1)
+    assert 1 == Cache.invalidate(:mod1)
+    assert 1 == Cache.invalidate()
   end
 
   defmemo(nothing_do(x))


### PR DESCRIPTION
by setting config :memoize, caches: [ ModuleName ] in your config file
you can make use of this feature. it is backwards compatible with the
old way of doing things, and forked the default code leaving behind a
simple module that will ignore these changes as best it can.  I still
need to fix evection  but will get to that soon.