### PR TITLE
Fix infinite loop if cache process crashes

### DIFF
--- a/test/memoize_cache_test.exs
+++ b/test/memoize_cache_test.exs
@@ -133,6 +133,18 @@ defmodule Memoize.CacheTest do
 
   end
 
+  @tag timeout: 100
+  test "doesn't block if caching process exited or crashed" do
+    pid = spawn(fn ->
+      Memoize.Cache.get_or_run(:key, fn -> :erlang.exit(self(), :normal) end)
+    end)
+
+    Process.monitor(pid)
+    assert_receive {:DOWN, _ref, :process, ^pid, :normal}
+
+    assert 1 == Memoize.Cache.get_or_run(:key, fn -> 1 end)
+  end
+
   defp cache_with_call_count(key, wait_time) do
     Process.sleep(wait_time)
 


### PR DESCRIPTION
This PR should fix issue https://github.com/melpon/memoize/issues/13

What happens is that when caching starts the `:running` flag is set and if the `fun.()` call shuts down it'll stay in the `:running` state.
Now if that happens I've added a call to delete the `:running` flag.

You can also easily recreate this issue with this https://github.com/melpon/memoize/issues/13#issuecomment-718702173

